### PR TITLE
Add F-Droid badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ BluePass
 ========
 
 [![Build Status](https://app.travis-ci.com/boon-code/bluepass.svg)](https://app.travis-ci.com/github/boon-code/bluepass)
+[![F-Droid version](https://img.shields.io/f-droid/v/org.booncode.bluepass4)](https://f-droid.org/packages/org.booncode.bluepass4)
 
 BluePass extracts two factor authentication codes (2FA) from SMS and sends them
 to a paired device via Bluetooth RFCOMM.
@@ -14,4 +15,8 @@ All images in this repository are created by the author and may be used as publi
 
 # F-Droid
 
-I would like this app to be included in F-Droid 😀
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
+    alt="Get it on F-Droid"
+    height="80">](https://f-droid.org/packages/org.booncode.bluepass4)
+
+I fully support the inclusion of this app in F-Droid 😀


### PR DESCRIPTION
- Correct README to clearly state that the application is already
  added to F-Droid (and that the author is welcoming it)
- Add "Get it on F-Droid" badge
- Add F-Droid version badge from shields.io
- Fixes issue #3